### PR TITLE
Update to Latest Stable Hive and SOLR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 *.war
 *.ear
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -71,21 +71,21 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-metastore</artifactId>
-			<version>0.7.1-SNAPSHOT</version>
+			<version>0.12.0</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-serde</artifactId>
-			<version>0.7.1-SNAPSHOT</version>
+			<version>0.12.0</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase</artifactId>
-			<version>0.90.3</version>
+			<version>0.94.12</version>
 			<type>jar</type>
 			<scope>provided</scope>
 			<exclusions>
@@ -98,13 +98,19 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
-			<version>0.7.1-SNAPSHOT</version>
+			<version>0.12.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
-			<version>4.1.0</version>
+			<version>4.6.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-core</artifactId>
+			<version>1.2.1</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/chimpler/hive/solr/ConfigurationUtil.java
+++ b/src/main/java/com/chimpler/hive/solr/ConfigurationUtil.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -33,6 +34,15 @@ public class ConfigurationUtil {
 	public final static int getNumOutputBufferRows(Configuration conf) {
 		String value = conf.get(BUFFER_OUT_ROWS, "-1");
 		return Integer.parseInt(value);
+	}
+	
+	public static void copySolrProperties(Properties from, JobConf to) {
+    	for (String key : ALL_PROPERTIES) {
+            String value = from.getProperty(key);
+            if (value != null) {
+            	to.set(key, value);
+            }
+    	}
 	}
 
     public static void copySolrProperties(Properties from,

--- a/src/main/java/com/chimpler/hive/solr/SolrSerDe.java
+++ b/src/main/java/com/chimpler/hive/solr/SolrSerDe.java
@@ -10,6 +10,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde.Constants;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
@@ -199,5 +200,10 @@ public class SolrSerDe implements SerDe {
 			}
 		}
 		return cachedWritable;
+	}
+
+	@Override
+	public SerDeStats getSerDeStats() {
+		return new SerDeStats();
 	}
 }

--- a/src/main/java/com/chimpler/hive/solr/SolrStorageHandler.java
+++ b/src/main/java/com/chimpler/hive/solr/SolrStorageHandler.java
@@ -14,9 +14,11 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
@@ -111,5 +113,28 @@ public class SolrStorageHandler implements HiveStorageHandler {
 			// nothing to do...
 		}
 
+	}
+
+	@Override
+	public void configureInputJobProperties(TableDesc arg0,
+			Map<String, String> arg1) {
+		// do nothing by default
+	}
+
+	@Override
+	public void configureJobConf(TableDesc arg0, JobConf arg1) {
+		// do nothing by default
+	}
+
+	@Override
+	public void configureOutputJobProperties(TableDesc arg0,
+			Map<String, String> arg1) {
+		// do nothing by default
+	}
+
+	@Override
+	public HiveAuthorizationProvider getAuthorizationProvider()
+			throws HiveException {
+		return new DefaultHiveAuthorizationProvider();
 	}
 }

--- a/src/main/java/com/chimpler/hive/solr/SolrStorageHandler.java
+++ b/src/main/java/com/chimpler/hive/solr/SolrStorageHandler.java
@@ -30,8 +30,7 @@ public class SolrStorageHandler implements HiveStorageHandler {
 	}
 
 	@Override
-	public void configureTableJobProperties(TableDesc tableDesc,
-			Map<String, String> jobProperties) {
+	public void configureTableJobProperties(TableDesc tableDesc, Map<String, String> jobProperties) {
 		Properties properties = tableDesc.getProperties();
 		ConfigurationUtil.copySolrProperties(properties, jobProperties);
 	}
@@ -116,20 +115,21 @@ public class SolrStorageHandler implements HiveStorageHandler {
 	}
 
 	@Override
-	public void configureInputJobProperties(TableDesc arg0,
-			Map<String, String> arg1) {
-		// do nothing by default
+	public void configureInputJobProperties(TableDesc tableDescription, Map<String, String> jobProperties) {
+		Properties properties = tableDescription.getProperties();
+		ConfigurationUtil.copySolrProperties(properties, jobProperties);
 	}
 
 	@Override
-	public void configureJobConf(TableDesc arg0, JobConf arg1) {
-		// do nothing by default
+	public void configureJobConf(TableDesc tableDescription, JobConf config) {
+		Properties properties = tableDescription.getProperties();
+		ConfigurationUtil.copySolrProperties(properties, config);
 	}
 
 	@Override
-	public void configureOutputJobProperties(TableDesc arg0,
-			Map<String, String> arg1) {
-		// do nothing by default
+	public void configureOutputJobProperties(TableDesc tableDescription, Map<String, String> jobProperties) {
+		Properties properties = tableDescription.getProperties();
+		ConfigurationUtil.copySolrProperties(properties, jobProperties);
 	}
 
 	@Override

--- a/src/main/java/com/chimpler/hive/solr/SolrTable.java
+++ b/src/main/java/com/chimpler/hive/solr/SolrTable.java
@@ -1,19 +1,11 @@
 package com.chimpler.hive.solr;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrDocumentList;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 
 public class SolrTable {


### PR DESCRIPTION
The below represents a patch to get the hive serde to work with the latest SOLR (4.6.x) and Hive (0.12). Looks like SerDe is deprecated, but I tested on the latest version and it still works as expected.
